### PR TITLE
Update of clean arch flow dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,19 +63,20 @@ To run this application, you must have to [create a Firebase Project](https://fi
 Afterwards, you must have to download the `google_services.json` file from the firebase console and add it `app` module root folder.
 If you want to save data on Firebase Cloud Firestore, [enable this database](https://firebase.google.com/docs/firestore/quickstart) for your project in Firebase Console. Also [enable the Firebase Cloud Storage](https://firebase.google.com/docs/storage/android/start).
 
-To choose the repository to save applications data, just make the following change in the [PresentationModule.kt](./presentation/src/main/java/dominando/android/presentation/di/PresentationModule.kt) file.
-```kotlin
-val presentationModule = module {
+To choose the data source you will save application data, just make the following change in the [DataModules.kt](./data/src/main/java/dominando/android/data/repository/BooksRepositoryImpl.kt) file.
 
-    single {
-        // Use either of the lines below
-        
-        // Local repository with Room + SQLite
-        RoomRepository(AppDatabase.getDatabase(application), LocalFileHelper()) as BooksRepository
-        // Remote repository with Firebase
-        FbRepository() as BooksRepository
-    }
+```kotlin
+internal class BooksRepositoryImpl(
+   // Change RoomLocalData to FBData interface
+   private val localData: RoomLocalData,
+   private val entityMapper: Mapper<BookData, Book>,
+   private val dataMapper: Mapper<Book, BookData>
+) : BooksRepository {
+
+    ...
+}
 ```
+
 And that's it! You're good to go.
 
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ To run this application, you must have to [create a Firebase Project](https://fi
 Afterwards, you must have to download the `google_services.json` file from the firebase console and add it `app` module root folder.
 If you want to save data on Firebase Cloud Firestore, [enable this database](https://firebase.google.com/docs/firestore/quickstart) for your project in Firebase Console. Also [enable the Firebase Cloud Storage](https://firebase.google.com/docs/storage/android/start).
 
-To choose the data source you will save application data, just make the following change in the [DataModules.kt](./data/src/main/java/dominando/android/data/repository/BooksRepositoryImpl.kt) file.
+To choose the data source you will save application data, just make the following change in the [BooksRepositoryImpl.kt](./data/src/main/java/dominando/android/data/repository/BooksRepositoryImpl.kt) file.
 
 ```kotlin
 internal class BooksRepositoryImpl(

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -49,6 +49,7 @@ dependencies {
     implementation project(":domain")
     implementation project(":data_room")
     implementation project(":data")
+    implementation project(":data_fb")
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation "androidx.appcompat:appcompat:$appcompat_version"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -46,6 +46,9 @@ android {
 
 dependencies {
     implementation project(":presentation")
+    implementation project(":domain")
+    implementation project(":data_room")
+    implementation project(":data")
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation "androidx.appcompat:appcompat:$appcompat_version"
@@ -65,6 +68,7 @@ dependencies {
 
     implementation "org.koin:koin-core:$koin_version"
     implementation "org.koin:koin-android:$koin_version"
+    implementation "org.koin:koin-android-viewmodel:$koin_version"
     implementation "org.koin:koin-android-scope:$koin_version"
 
     testImplementation "junit:junit:$junit_version"

--- a/app/src/main/java/dominando/android/livros/BookApp.kt
+++ b/app/src/main/java/dominando/android/livros/BookApp.kt
@@ -1,8 +1,11 @@
 package dominando.android.livros
 
 import android.app.Application
-import dominando.android.livros.di.appModule
-import dominando.android.presentation.di.presentationModule
+import dominando.android.data.di.DataModules
+import dominando.android.data_room.di.DataRoomModules
+import dominando.android.domain.di.DomainModules
+import dominando.android.livros.di.AppModule
+import dominando.android.presentation.di.PresentationModule
 import org.koin.android.ext.koin.androidContext
 import org.koin.core.context.startKoin
 
@@ -12,11 +15,16 @@ class BookApp : Application() {
         super.onCreate()
         startKoin {
             androidContext(this@BookApp)
-            modules(
-                    listOf(
-                            appModule, presentationModule
-                    )
-            )
         }
+
+        loadAllModules()
+    }
+
+    private fun loadAllModules() {
+        AppModule.load()
+        DataRoomModules.load()
+        DataModules.load()
+        DomainModules.load()
+        PresentationModule.load()
     }
 }

--- a/app/src/main/java/dominando/android/livros/BookApp.kt
+++ b/app/src/main/java/dominando/android/livros/BookApp.kt
@@ -2,6 +2,7 @@ package dominando.android.livros
 
 import android.app.Application
 import dominando.android.data.di.DataModules
+import dominando.android.data_fb.di.DataFBModules
 import dominando.android.data_room.di.DataRoomModules
 import dominando.android.domain.di.DomainModules
 import dominando.android.livros.di.AppModule
@@ -13,6 +14,7 @@ class BookApp : Application() {
 
     override fun onCreate() {
         super.onCreate()
+
         startKoin {
             androidContext(this@BookApp)
         }
@@ -23,6 +25,7 @@ class BookApp : Application() {
     private fun loadAllModules() {
         AppModule.load()
         DataRoomModules.load()
+        DataFBModules.load()
         DataModules.load()
         DomainModules.load()
         PresentationModule.load()

--- a/app/src/main/java/dominando/android/livros/BookDetailsFragment.kt
+++ b/app/src/main/java/dominando/android/livros/BookDetailsFragment.kt
@@ -13,12 +13,12 @@ import dominando.android.livros.common.Constants.EXTRA_BOOK
 import dominando.android.livros.databinding.FragmentBookDetailsBinding
 import dominando.android.presentation.BookDetailsViewModel
 import dominando.android.presentation.binding.Book
-import org.koin.android.ext.android.inject
+import org.koin.android.viewmodel.ext.android.viewModel
 import org.koin.core.parameter.parametersOf
 
 class BookDetailsFragment : BaseFragment() {
 
-    private val viewModel: BookDetailsViewModel by inject {
+    private val viewModel: BookDetailsViewModel by viewModel {
         parametersOf(arguments?.getParcelable<Book>(EXTRA_BOOK)?.id)
     }
 

--- a/app/src/main/java/dominando/android/livros/BookFormFragment.kt
+++ b/app/src/main/java/dominando/android/livros/BookFormFragment.kt
@@ -20,9 +20,11 @@ import dominando.android.presentation.BookFormViewModel
 import dominando.android.presentation.ViewState
 import dominando.android.presentation.binding.Book
 import org.koin.android.ext.android.inject
+import org.koin.android.viewmodel.ext.android.viewModel
 
 class BookFormFragment : BaseFragment() {
-    private val viewModel: BookFormViewModel by inject()
+
+    private val viewModel: BookFormViewModel by viewModel()
 
     private val filePicker: FilePicker by lazy {
         FilePicker(requireContext())

--- a/app/src/main/java/dominando/android/livros/BookListFragment.kt
+++ b/app/src/main/java/dominando/android/livros/BookListFragment.kt
@@ -17,10 +17,11 @@ import dominando.android.livros.common.BaseFragment
 import dominando.android.livros.databinding.FragmentBookListBinding
 import dominando.android.presentation.BookListViewModel
 import dominando.android.presentation.ViewState
-import org.koin.android.ext.android.inject
+import org.koin.android.viewmodel.ext.android.viewModel
 
 class BookListFragment : BaseFragment() {
-    private val viewModel: BookListViewModel by inject()
+
+    private val viewModel: BookListViewModel by viewModel()
     private lateinit var dataBinding: FragmentBookListBinding
 
     private val bookAdapter by lazy {

--- a/app/src/main/java/dominando/android/livros/di/AppModule.kt
+++ b/app/src/main/java/dominando/android/livros/di/AppModule.kt
@@ -6,15 +6,20 @@ import dominando.android.livros.auth.FirebaseSignIn
 import dominando.android.livros.router.AppRouter
 import dominando.android.presentation.Router
 import dominando.android.presentation.auth.Auth
+import org.koin.core.context.loadKoinModules
 import org.koin.dsl.module
 
-val appModule = module {
+object AppModule {
 
-    factory { (activity: FragmentActivity) ->
-        AppRouter(activity) as Router
-    }
+    fun load() {
+        loadKoinModules(module {
+            factory { (activity: FragmentActivity) ->
+                AppRouter(activity) as Router
+            }
 
-    factory { (activity: FragmentActivity) ->
-        FirebaseSignIn(activity) as Auth<Int, Intent>
+            factory { (activity: FragmentActivity) ->
+                FirebaseSignIn(activity) as Auth<Int, Intent>
+            }
+        })
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,7 @@ buildscript {
         room_version = "2.2.5"
         testrules_version = "1.2.0"
         testrunner_version = '1.1.1'
+        kotlin_test_version = '1.4.0'
     }
 
     repositories {

--- a/commons.gradle
+++ b/commons.gradle
@@ -1,0 +1,9 @@
+dependencies {
+    implementation "org.koin:koin-core:$koin_version"
+    implementation "org.koin:koin-android:$koin_version"
+
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutines_version"
+
+    testImplementation "junit:junit:$junit_version"
+}

--- a/data/build.gradle
+++ b/data/build.gradle
@@ -2,9 +2,11 @@ apply plugin: 'java-library'
 apply plugin: 'kotlin'
 
 dependencies {
+    implementation project(":domain")
+
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 
-    api "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutines_version"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutines_version"
 
     testImplementation "junit:junit:$junit_version"
 }

--- a/data/build.gradle
+++ b/data/build.gradle
@@ -1,12 +1,7 @@
 apply plugin: 'java-library'
 apply plugin: 'kotlin'
+apply from: "$rootProject.projectDir/commons.gradle"
 
 dependencies {
     implementation project(":domain")
-
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutines_version"
-
-    testImplementation "junit:junit:$junit_version"
 }

--- a/data/build.gradle
+++ b/data/build.gradle
@@ -4,4 +4,7 @@ apply from: "$rootProject.projectDir/commons.gradle"
 
 dependencies {
     implementation project(":domain")
+
+    testImplementation "io.mockk:mockk:$mockk_version"
+    testImplementation "org.jetbrains.kotlin:kotlin-test:$kotlin_test_version"
 }

--- a/data/src/main/java/dominando/android/data/di/DataModules.kt
+++ b/data/src/main/java/dominando/android/data/di/DataModules.kt
@@ -13,7 +13,7 @@ object DataModules {
         loadKoinModules(module {
             factory<BooksRepository> {
                 BooksRepositoryImpl(
-                    roomLocalData = get(),
+                    localData = get(),
                     entityMapper = BooksMapper(),
                     dataMapper = BooksDataMapper()
                 )

--- a/data/src/main/java/dominando/android/data/di/DataModules.kt
+++ b/data/src/main/java/dominando/android/data/di/DataModules.kt
@@ -1,0 +1,23 @@
+package dominando.android.data.di
+
+import dominando.android.data.mapper.BooksDataMapper
+import dominando.android.data.mapper.BooksMapper
+import dominando.android.data.repository.BooksRepositoryImpl
+import dominando.android.domain.repository.BooksRepository
+import org.koin.core.context.loadKoinModules
+import org.koin.dsl.module
+
+object DataModules {
+
+    fun load() {
+        loadKoinModules(module {
+            factory<BooksRepository> {
+                BooksRepositoryImpl(
+                    roomLocalData = get(),
+                    entityMapper = BooksMapper(),
+                    dataMapper = BooksDataMapper()
+                )
+            }
+        })
+    }
+}

--- a/data/src/main/java/dominando/android/data/mapper/BooksDataMapper.kt
+++ b/data/src/main/java/dominando/android/data/mapper/BooksDataMapper.kt
@@ -1,0 +1,42 @@
+package dominando.android.data.mapper
+
+import dominando.android.data.model.BookData
+import dominando.android.data.model.MediaTypeData
+import dominando.android.data.model.PublisherData
+import dominando.android.domain.entity.Book
+import dominando.android.domain.entity.MediaType
+import dominando.android.domain.entity.Publisher
+
+class BooksDataMapper : Mapper<Book, BookData> {
+
+    override fun map(source: Book): BookData {
+        return BookData(
+            id = source.id,
+            title = source.title,
+            author = source.author,
+            coverUrl = source.coverUrl,
+            pages = source.pages,
+            year = source.year,
+            publisher = mapPublisher(source.publisher),
+            available = source.available,
+            mediaType = mapMediaType(source.mediaType),
+           rating = source.rating
+        )
+    }
+
+    private fun mapPublisher(publisher: Publisher?): PublisherData? {
+        return publisher?.run {
+            PublisherData(
+                id = id,
+                name = name
+            )
+        }
+    }
+
+    private fun mapMediaType(mediaType: MediaType): MediaTypeData{
+        return when (mediaType) {
+            MediaType.PAPER -> MediaTypeData.PAPER
+            MediaType.EBOOK -> MediaTypeData.EBOOK
+        }
+    }
+}

--- a/data/src/main/java/dominando/android/data/mapper/BooksMapper.kt
+++ b/data/src/main/java/dominando/android/data/mapper/BooksMapper.kt
@@ -1,0 +1,42 @@
+package dominando.android.data.mapper
+
+import dominando.android.data.model.BookData
+import dominando.android.data.model.MediaTypeData
+import dominando.android.data.model.PublisherData
+import dominando.android.domain.entity.Book
+import dominando.android.domain.entity.MediaType
+import dominando.android.domain.entity.Publisher
+
+internal class BooksMapper : Mapper<BookData, Book> {
+
+    override fun map(source: BookData): Book {
+        return Book(
+            id = source.id,
+            title = source.title,
+            author = source.author,
+            coverUrl = source.coverUrl,
+            pages = source.pages,
+            year = source.year,
+            publisher = mapPublisher(source.publisher),
+            available = source.available,
+            mediaType = mapMediaType(source.mediaType),
+            rating = source.rating
+        )
+    }
+
+    private fun mapPublisher(publisher: PublisherData?): Publisher? {
+        return publisher?.run {
+            Publisher(
+                id = id,
+                name = name
+            )
+        }
+    }
+
+    private fun mapMediaType(mediaType: MediaTypeData): MediaType {
+        return when (mediaType) {
+            MediaTypeData.PAPER -> MediaType.PAPER
+            MediaTypeData.EBOOK -> MediaType.EBOOK
+        }
+    }
+}

--- a/data/src/main/java/dominando/android/data/mapper/Mapper.kt
+++ b/data/src/main/java/dominando/android/data/mapper/Mapper.kt
@@ -1,0 +1,5 @@
+package dominando.android.data.mapper
+
+internal interface Mapper<I, O> {
+    fun map(source: I): O
+}

--- a/data/src/main/java/dominando/android/data/model/BookData.kt
+++ b/data/src/main/java/dominando/android/data/model/BookData.kt
@@ -1,0 +1,14 @@
+package dominando.android.data.model
+
+data class BookData(
+    var id: String = "",
+    var title: String = "",
+    var author: String = "",
+    var coverUrl: String = "",
+    var pages: Int = 0,
+    var year: Int = 0,
+    var publisher: PublisherData? = null,
+    var available: Boolean = false,
+    var mediaType: MediaTypeData = MediaTypeData.PAPER,
+    var rating: Float = 0f
+)

--- a/data/src/main/java/dominando/android/data/model/MediaTypeData.kt
+++ b/data/src/main/java/dominando/android/data/model/MediaTypeData.kt
@@ -1,5 +1,5 @@
 package dominando.android.data.model
 
-enum class MediaType {
+enum class MediaTypeData {
     PAPER, EBOOK
 }

--- a/data/src/main/java/dominando/android/data/model/PublisherData.kt
+++ b/data/src/main/java/dominando/android/data/model/PublisherData.kt
@@ -1,0 +1,6 @@
+package dominando.android.data.model
+
+data class PublisherData(
+    var id: String = "",
+    var name: String = ""
+)

--- a/data/src/main/java/dominando/android/data/repository/BooksRepositoryImpl.kt
+++ b/data/src/main/java/dominando/android/data/repository/BooksRepositoryImpl.kt
@@ -1,0 +1,32 @@
+package dominando.android.data.repository
+
+import dominando.android.data.mapper.Mapper
+import dominando.android.data.model.BookData
+import dominando.android.data.source.RoomLocalData
+import dominando.android.domain.entity.Book
+import dominando.android.domain.repository.BooksRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+internal class BooksRepositoryImpl(
+   private val roomLocalData: RoomLocalData,
+   private val entityMapper: Mapper<BookData, Book>,
+   private val dataMapper: Mapper<Book, BookData>
+) : BooksRepository {
+
+    override fun loadBooks(): Flow<List<Book>> {
+        return roomLocalData.loadBooks().map { it.map(entityMapper::map) }
+    }
+
+    override fun loadBook(bookId: String): Flow<Book?> {
+        return roomLocalData.loadBook(bookId).map{ it?.let(entityMapper::map) }
+    }
+
+    override suspend fun saveBook(book: Book) {
+        return roomLocalData.saveBook(dataMapper.map(book))
+    }
+
+    override suspend fun remove(book: Book) {
+        return roomLocalData.remove(dataMapper.map(book))
+    }
+}

--- a/data/src/main/java/dominando/android/data/repository/BooksRepositoryImpl.kt
+++ b/data/src/main/java/dominando/android/data/repository/BooksRepositoryImpl.kt
@@ -9,24 +9,25 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 
 internal class BooksRepositoryImpl(
-   private val roomLocalData: RoomLocalData,
+   //
+   private val localData: RoomLocalData,
    private val entityMapper: Mapper<BookData, Book>,
    private val dataMapper: Mapper<Book, BookData>
 ) : BooksRepository {
 
     override fun loadBooks(): Flow<List<Book>> {
-        return roomLocalData.loadBooks().map { it.map(entityMapper::map) }
+        return localData.loadBooks().map { it.map(entityMapper::map) }
     }
 
     override fun loadBook(bookId: String): Flow<Book?> {
-        return roomLocalData.loadBook(bookId).map{ it?.let(entityMapper::map) }
+        return localData.loadBook(bookId).map{ it?.let(entityMapper::map) }
     }
 
     override suspend fun saveBook(book: Book) {
-        return roomLocalData.saveBook(dataMapper.map(book))
+        return localData.saveBook(dataMapper.map(book))
     }
 
     override suspend fun remove(book: Book) {
-        return roomLocalData.remove(dataMapper.map(book))
+        return localData.remove(dataMapper.map(book))
     }
 }

--- a/data/src/main/java/dominando/android/data/repository/BooksRepositoryImpl.kt
+++ b/data/src/main/java/dominando/android/data/repository/BooksRepositoryImpl.kt
@@ -9,7 +9,6 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 
 internal class BooksRepositoryImpl(
-   //
    private val localData: RoomLocalData,
    private val entityMapper: Mapper<BookData, Book>,
    private val dataMapper: Mapper<Book, BookData>

--- a/data/src/main/java/dominando/android/data/source/FBData.kt
+++ b/data/src/main/java/dominando/android/data/source/FBData.kt
@@ -3,7 +3,7 @@ package dominando.android.data.source
 import dominando.android.data.model.BookData
 import kotlinx.coroutines.flow.Flow
 
-interface FbData {
+interface FBData {
     fun loadBooks(): Flow<List<BookData>>
     fun loadBook(bookId: String): Flow<BookData?>
     suspend fun saveBook(book: BookData)

--- a/data/src/main/java/dominando/android/data/source/FbData.kt
+++ b/data/src/main/java/dominando/android/data/source/FbData.kt
@@ -1,0 +1,11 @@
+package dominando.android.data.source
+
+import dominando.android.data.model.BookData
+import kotlinx.coroutines.flow.Flow
+
+interface FbData {
+    fun loadBooks(): Flow<List<BookData>>
+    fun loadBook(bookId: String): Flow<BookData?>
+    suspend fun saveBook(book: BookData)
+    suspend fun remove(book: BookData)
+}

--- a/data/src/main/java/dominando/android/data/source/RoomLocalData.kt
+++ b/data/src/main/java/dominando/android/data/source/RoomLocalData.kt
@@ -1,0 +1,11 @@
+package dominando.android.data.source
+
+import dominando.android.data.model.BookData
+import kotlinx.coroutines.flow.Flow
+
+interface RoomLocalData {
+    fun loadBooks(): Flow<List<BookData>>
+    fun loadBook(bookId: String): Flow<BookData?>
+    suspend fun saveBook(book: BookData)
+    suspend fun remove(book: BookData)
+}

--- a/data/src/main/java/dominando/android/data/util/FileHelper.kt
+++ b/data/src/main/java/dominando/android/data/util/FileHelper.kt
@@ -1,8 +1,0 @@
-package dominando.android.data.util
-
-import dominando.android.data.model.Book
-
-interface FileHelper {
-    fun saveCover(book: Book): Boolean
-    fun deleteExistingCover(book: Book): Boolean
-}

--- a/data/src/test/java/dominando/android/data/factory/DataFactory.kt
+++ b/data/src/test/java/dominando/android/data/factory/DataFactory.kt
@@ -1,0 +1,92 @@
+package dominando.android.data.factory
+
+import dominando.android.data.model.BookData
+import dominando.android.data.model.MediaTypeData
+import dominando.android.data.model.PublisherData
+import dominando.android.domain.entity.Book
+import dominando.android.domain.entity.MediaType
+import dominando.android.domain.entity.Publisher
+import java.util.*
+
+object DataFactory {
+
+    fun dummyDataBookList() = listOf(
+            BookData().apply {
+                id = "48546423158"
+                title = "Dominando o Android"
+                author = "Nelson Glauber"
+                available = true
+                coverUrl = ""
+                pages = 954
+                publisher = PublisherData("15638546", "Novatec")
+                year = 2018
+                mediaType = MediaTypeData.PAPER
+                rating = 5f
+            },
+            BookData().apply {
+                id = "48546423159"
+                title = "Clean Code"
+                author = "Uncle Bob"
+                available = true
+                coverUrl = ""
+                pages = 465
+                publisher = PublisherData("15638547", "Outro")
+                year = 2009
+                mediaType = MediaTypeData.EBOOK
+                rating = 5f
+            }
+    )
+
+    fun dummyDataBook() = BookData().apply {
+        id = "48546423158"
+        title = "Dominando o Android"
+        author = "Nelson Glauber"
+        available = true
+        coverUrl = ""
+        pages = 954
+        publisher = PublisherData("14556513", "Novatec")
+        year = 2018
+        mediaType = MediaTypeData.EBOOK
+        rating = 5f
+    }
+
+    fun dummyBookList() = listOf(
+            Book().apply {
+                id = "48546423158"
+                title = "Dominando o Android"
+                author = "Nelson Glauber"
+                available = true
+                coverUrl = ""
+                pages = 954
+                publisher = Publisher("15638546", "Novatec")
+                year = 2018
+                mediaType = MediaType.PAPER
+                rating = 5f
+            },
+            Book().apply {
+                id = "48546423159"
+                title = "Clean Code"
+                author = "Uncle Bob"
+                available = true
+                coverUrl = ""
+                pages = 465
+                publisher = Publisher("15638547", "Outro")
+                year = 2009
+                mediaType = MediaType.EBOOK
+                rating = 5f
+            }
+    )
+
+    fun dummyBook() = Book().apply {
+        id = "48546423158"
+        title = "Dominando o Android"
+        author = "Nelson Glauber"
+        available = true
+        coverUrl = ""
+        pages = 954
+        publisher = Publisher("14556513", "Novatec")
+        year = 2018
+        mediaType = MediaType.EBOOK
+        rating = 5f
+    }
+}

--- a/data/src/test/java/dominando/android/data/mapper/BooksDataMapperTest.kt
+++ b/data/src/test/java/dominando/android/data/mapper/BooksDataMapperTest.kt
@@ -1,0 +1,25 @@
+package dominando.android.data.mapper
+
+import dominando.android.data.factory.DataFactory
+import dominando.android.data.model.BookData
+import dominando.android.domain.entity.Book
+import org.junit.Test
+import kotlin.test.assertEquals
+
+class BooksDataMapperTest {
+
+    private val mapper: Mapper<Book, BookData> = BooksDataMapper()
+
+    @Test
+    fun testBookDataEqualsDomain()  {
+        // Given
+        val expected = DataFactory.dummyDataBook()
+        val book = DataFactory.dummyBook()
+
+        // When
+        val result = mapper.map(book)
+
+        // Then
+        assertEquals(expected, result)
+    }
+}

--- a/data/src/test/java/dominando/android/data/mapper/BooksMapperTest.kt
+++ b/data/src/test/java/dominando/android/data/mapper/BooksMapperTest.kt
@@ -1,0 +1,25 @@
+package dominando.android.data.mapper
+
+import dominando.android.data.factory.DataFactory
+import dominando.android.data.model.BookData
+import dominando.android.domain.entity.Book
+import org.junit.Test
+import kotlin.test.assertEquals
+
+internal class BooksMapperTest {
+
+    private val mapper: Mapper<BookData,Book> = BooksMapper()
+
+    @Test
+    fun testBookDomainEqualsData()  {
+        // Given
+        val expected = DataFactory.dummyBook()
+        val book = DataFactory.dummyDataBook()
+
+        // When
+        val result = mapper.map(book)
+
+        // Then
+        assertEquals(expected, result)
+    }
+}

--- a/data/src/test/java/dominando/android/data/repository/BooksRepositoryTest.kt
+++ b/data/src/test/java/dominando/android/data/repository/BooksRepositoryTest.kt
@@ -1,0 +1,89 @@
+package dominando.android.data.repository
+
+import dominando.android.data.factory.DataFactory
+import dominando.android.data.mapper.BooksDataMapper
+import dominando.android.data.mapper.BooksMapper
+import dominando.android.data.source.RoomLocalData
+import dominando.android.domain.repository.BooksRepository
+import io.mockk.clearMocks
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import kotlin.test.assertEquals as kotlinAssertEquals
+
+internal class BooksRepositoryTest {
+
+    private val entityMapper = BooksMapper()
+    private val dataMapper = BooksDataMapper()
+    private val roomLocalData = mockk<RoomLocalData>(relaxed = true)
+    private val booksRepository: BooksRepository =
+            BooksRepositoryImpl(roomLocalData, entityMapper, dataMapper)
+
+    @After
+    fun tearDown() {
+        clearMocks(roomLocalData)
+    }
+
+    @Test
+    fun testLoadedAllBooks() = runBlocking {
+        // Given
+        val expectedBooks = DataFactory.dummyBookList()
+
+        coEvery { roomLocalData.loadBooks() } returns flowOf(DataFactory.dummyDataBookList())
+
+        // When
+        val result = booksRepository.loadBooks().first()
+
+        // Then
+        assertEquals(expectedBooks.size, result.size)
+        kotlinAssertEquals(expectedBooks, result)
+    }
+
+    @Test
+    fun testLoadedSingleBook() = runBlocking {
+        // Given
+        val id = "0"
+        val expectedBook = DataFactory.dummyBook()
+
+        coEvery { roomLocalData.loadBook(id) } returns flowOf(DataFactory.dummyDataBook())
+
+        // When
+        val result = booksRepository.loadBook(id).first()
+
+        // Then
+        assertEquals(expectedBook, result)
+    }
+
+    @Test
+    fun testSavedBook() = runBlocking {
+        // Given
+        val expectedBook = DataFactory.dummyDataBook()
+        val book = DataFactory.dummyBook()
+
+        // When
+        booksRepository.saveBook(book)
+
+        // Then
+        coVerify { roomLocalData.saveBook(expectedBook) }
+    }
+
+    @Test
+    fun testRemoveBook() = runBlocking {
+        // Given
+        val expectedBook = DataFactory.dummyDataBook()
+        val book = DataFactory.dummyBook()
+
+        // When
+        booksRepository.remove(book)
+
+        // Then
+        coVerify { roomLocalData.remove(expectedBook) }
+    }
+
+}

--- a/data_fb/build.gradle
+++ b/data_fb/build.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
+apply from: "$rootProject.projectDir/commons.gradle"
 
 android {
     compileSdkVersion compile_sdk_version

--- a/data_fb/build.gradle
+++ b/data_fb/build.gradle
@@ -21,6 +21,9 @@ android {
 dependencies {
     implementation project(":data")
 
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutines_version"
+
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation "com.google.firebase:firebase-core:$firebase_core_version"
     implementation "com.google.firebase:firebase-firestore:$firebase_firestore_version"

--- a/data_fb/src/main/java/dominando/android/data_fb/FBDataImpl.kt
+++ b/data_fb/src/main/java/dominando/android/data_fb/FBDataImpl.kt
@@ -9,7 +9,7 @@ import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.SetOptions
 import com.google.firebase.storage.FirebaseStorage
 import dominando.android.data.model.BookData
-import dominando.android.data.source.FbData
+import dominando.android.data.source.FBData
 import java.io.ByteArrayOutputStream
 import java.io.File
 import java.io.FileOutputStream
@@ -21,7 +21,7 @@ import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
 
-internal class FbDataImpl : FbData {
+internal class FBDataImpl : FBData {
 
     private val fbAuth = FirebaseAuth.getInstance()
     private val firestore = FirebaseFirestore.getInstance()

--- a/data_fb/src/main/java/dominando/android/data_fb/FbDataImpl.kt
+++ b/data_fb/src/main/java/dominando/android/data_fb/FbDataImpl.kt
@@ -21,7 +21,7 @@ import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
 
-class FbDataImpl : FbData {
+internal class FbDataImpl : FbData {
 
     private val fbAuth = FirebaseAuth.getInstance()
     private val firestore = FirebaseFirestore.getInstance()

--- a/data_fb/src/main/java/dominando/android/data_fb/FbDataImpl.kt
+++ b/data_fb/src/main/java/dominando/android/data_fb/FbDataImpl.kt
@@ -8,8 +8,8 @@ import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.SetOptions
 import com.google.firebase.storage.FirebaseStorage
-import dominando.android.data.BooksRepository
-import dominando.android.data.model.Book
+import dominando.android.data.model.BookData
+import dominando.android.data.source.FbData
 import java.io.ByteArrayOutputStream
 import java.io.File
 import java.io.FileOutputStream
@@ -21,12 +21,13 @@ import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
 
-class FbRepository : BooksRepository {
+class FbDataImpl : FbData {
+
     private val fbAuth = FirebaseAuth.getInstance()
     private val firestore = FirebaseFirestore.getInstance()
     private val storageRef = FirebaseStorage.getInstance().reference.child(BOOKS_KEY)
 
-    override suspend fun saveBook(book: Book) {
+    override suspend fun saveBook(book: BookData) {
         return suspendCoroutine { continuation ->
             val currentUser = fbAuth.currentUser
             if (currentUser == null) {
@@ -61,7 +62,7 @@ class FbRepository : BooksRepository {
         }
     }
 
-    private fun uploadFile(book: Book) {
+    private fun uploadFile(book: BookData) {
         uploadPhoto(book).continueWithTask { urlTask ->
             File(book.coverUrl).delete()
             book.coverUrl = urlTask.result.toString()
@@ -73,7 +74,7 @@ class FbRepository : BooksRepository {
         }
     }
 
-    override fun loadBooks(): Flow<List<Book>> {
+    override fun loadBooks(): Flow<List<BookData>> {
         return callbackFlow {
             val currentUser = fbAuth.currentUser
             val subscription = firestore.collection(BOOKS_KEY)
@@ -86,13 +87,13 @@ class FbRepository : BooksRepository {
 
                         if (snapshot != null && !snapshot.isEmpty) {
                             val books = snapshot.map { document ->
-                                document.toObject(Book::class.java)
+                                document.toObject(BookData::class.java)
                             }
                             books.let {
                                 offer(it)
                             }
                         } else {
-                            offer(emptyList<Book>())
+                            offer(emptyList<BookData>())
                         }
                     }
             awaitClose {
@@ -101,7 +102,7 @@ class FbRepository : BooksRepository {
         }
     }
 
-    override fun loadBook(bookId: String): Flow<Book?> {
+    override fun loadBook(bookId: String): Flow<BookData?> {
         return callbackFlow {
             val subscription = firestore.collection(BOOKS_KEY)
                     .document(bookId)
@@ -111,7 +112,7 @@ class FbRepository : BooksRepository {
                             return@addSnapshotListener
                         }
                         if (snapshot != null && snapshot.exists()) {
-                            val book = snapshot.toObject(Book::class.java)
+                            val book = snapshot.toObject(BookData::class.java)
                             book?.let {
                                 offer(it)
                             }
@@ -123,7 +124,7 @@ class FbRepository : BooksRepository {
         }
     }
 
-    override suspend fun remove(book: Book) {
+    override suspend fun remove(book: BookData) {
         return suspendCoroutine { continuation ->
             val db = firestore
             db.collection(BOOKS_KEY)
@@ -149,7 +150,7 @@ class FbRepository : BooksRepository {
         }
     }
 
-    private fun uploadPhoto(book: Book): Task<Uri> {
+    private fun uploadPhoto(book: BookData): Task<Uri> {
         compressPhoto(book.coverUrl)
         val storageRef = storageRef.child(book.id)
         return storageRef.putFile(Uri.parse(book.coverUrl))

--- a/data_fb/src/main/java/dominando/android/data_fb/FileUtil.kt
+++ b/data_fb/src/main/java/dominando/android/data_fb/FileUtil.kt
@@ -1,13 +1,14 @@
 package dominando.android.data_fb
 
-import dominando.android.data.model.Book
+import dominando.android.data.model.BookData
 import java.io.File
 import java.io.FileInputStream
 import java.io.FileOutputStream
 import java.io.IOException
 
 object FileUtil {
-    fun pathFromBook(book: Book): String {
+
+    fun pathFromBook(book: BookData): String {
         return "/data/data/dominando.android.livros/files/${book.id}.jpg"
     }
     @Throws(IOException::class)

--- a/data_fb/src/main/java/dominando/android/data_fb/FileUtil.kt
+++ b/data_fb/src/main/java/dominando/android/data_fb/FileUtil.kt
@@ -6,7 +6,7 @@ import java.io.FileInputStream
 import java.io.FileOutputStream
 import java.io.IOException
 
-object FileUtil {
+internal object FileUtil {
 
     fun pathFromBook(book: BookData): String {
         return "/data/data/dominando.android.livros/files/${book.id}.jpg"

--- a/data_fb/src/main/java/dominando/android/data_fb/di/DataFBModules.kt
+++ b/data_fb/src/main/java/dominando/android/data_fb/di/DataFBModules.kt
@@ -1,0 +1,15 @@
+package dominando.android.data_fb.di
+
+import dominando.android.data.source.FbData
+import dominando.android.data_fb.FbDataImpl
+import org.koin.core.context.loadKoinModules
+import org.koin.dsl.module
+
+object DataFBModules {
+
+    fun load() {
+        loadKoinModules(module {
+            factory<FbData> { FbDataImpl() }
+        })
+    }
+}

--- a/data_fb/src/main/java/dominando/android/data_fb/di/DataFBModules.kt
+++ b/data_fb/src/main/java/dominando/android/data_fb/di/DataFBModules.kt
@@ -1,7 +1,7 @@
 package dominando.android.data_fb.di
 
-import dominando.android.data.source.FbData
-import dominando.android.data_fb.FbDataImpl
+import dominando.android.data.source.FBData
+import dominando.android.data_fb.FBDataImpl
 import org.koin.core.context.loadKoinModules
 import org.koin.dsl.module
 
@@ -9,7 +9,7 @@ object DataFBModules {
 
     fun load() {
         loadKoinModules(module {
-            factory<FbData> { FbDataImpl() }
+            factory<FBData> { FBDataImpl() }
         })
     }
 }

--- a/data_room/build.gradle
+++ b/data_room/build.gradle
@@ -1,6 +1,7 @@
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-kapt'
+apply from: "$rootProject.projectDir/commons.gradle"
 
 android {
     compileSdkVersion compile_sdk_version
@@ -32,7 +33,6 @@ dependencies {
     implementation "androidx.room:room-ktx:$room_version"
     kapt "androidx.room:room-compiler:$room_version"
 
-    testImplementation "junit:junit:$junit_version"
     testImplementation "androidx.room:room-testing:$room_version"
 
     androidTestImplementation "androidx.test.ext:junit:$testrunner_version"

--- a/data_room/src/androidTest/java/dominando/android/data_room/AppDatabaseTest.kt
+++ b/data_room/src/androidTest/java/dominando/android/data_room/AppDatabaseTest.kt
@@ -4,8 +4,8 @@ import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.room.Room
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
-import dominando.android.data.model.MediaType
-import dominando.android.data.model.Publisher
+import dominando.android.data.model.MediaTypeData
+import dominando.android.data.model.PublisherData
 import dominando.android.data_room.database.AppDatabase
 import dominando.android.data_room.entity.Book
 import java.util.UUID
@@ -32,9 +32,9 @@ class AppDatabaseTest {
             available = true,
             coverUrl = "",
             pages = 954,
-            publisher = Publisher(UUID.randomUUID().toString(), "Novatec"),
+            publisherData = PublisherData(UUID.randomUUID().toString(), "Novatec"),
             year = 2018,
-            mediaType = MediaType.EBOOK,
+            mediaTypeData = MediaTypeData.EBOOK,
             rating = 5f
     )
 
@@ -77,9 +77,9 @@ class AppDatabaseTest {
                 coverUrl = "www.nglauber.com.br",
                 pages = 1000,
                 year = 2016,
-                publisher = Publisher(UUID.randomUUID().toString(), "Test"),
+                publisherData = PublisherData(UUID.randomUUID().toString(), "Test"),
                 available = false,
-                mediaType = MediaType.PAPER,
+                mediaTypeData = MediaTypeData.PAPER,
                 rating = 2.5f
         )
         dao.save(updatedBook)

--- a/data_room/src/androidTest/java/dominando/android/data_room/RoomLocalDataImplTest.kt
+++ b/data_room/src/androidTest/java/dominando/android/data_room/RoomLocalDataImplTest.kt
@@ -4,10 +4,11 @@ import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.room.Room
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
-import dominando.android.data.model.Book
-import dominando.android.data.model.MediaType
-import dominando.android.data.model.Publisher
+import dominando.android.data.model.BookData
+import dominando.android.data.model.MediaTypeData
+import dominando.android.data.model.PublisherData
 import dominando.android.data_room.database.AppDatabase
+import dominando.android.data_room.filehelper.LocalFileHelper
 import java.io.File
 import java.util.UUID
 import kotlinx.coroutines.flow.first
@@ -20,29 +21,31 @@ import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
-class RoomRepositoryTest {
+class RoomLocalDataImplTest {
 
     @get:Rule
     val instantTaskExecutorRule = InstantTaskExecutorRule()
 
-    private lateinit var repo: RoomRepository
-    private lateinit var dummyBook: Book
+    private lateinit var repo: RoomLocalDataImpl
+    private lateinit var dummyBook: BookData
+
+    private val context = InstrumentationRegistry.getInstrumentation().context
+    private val database = AppDatabase::class.java
 
     @Before
     fun initDb() {
-        val db = Room.inMemoryDatabaseBuilder(InstrumentationRegistry.getInstrumentation().context,
-                AppDatabase::class.java).build()
-        repo = RoomRepository(db, LocalFileHelper())
-        dummyBook = Book().apply {
+        val db = Room.inMemoryDatabaseBuilder(context, database).build()
+        repo = RoomLocalDataImpl(db, LocalFileHelper())
+        dummyBook = BookData().apply {
             id = UUID.randomUUID().toString()
             title = "Dominando o Android"
             author = "Nelson Glauber"
             available = true
             coverUrl = ""
             pages = 954
-            publisher = dominando.android.data.model.Publisher(UUID.randomUUID().toString(), "Novatec")
+            publisher = PublisherData(UUID.randomUUID().toString(), "Novatec")
             year = 2018
-            mediaType = dominando.android.data.model.MediaType.EBOOK
+            mediaType = MediaTypeData.EBOOK
             rating = 5f
         }
     }
@@ -115,16 +118,16 @@ class RoomRepositoryTest {
         Assert.assertFalse(cover.exists())
     }
 
-    private fun newBook(bookId: String) = Book().apply {
+    private fun newBook(bookId: String) = BookData().apply {
         id = bookId
         title = "Novo"
         author = "Nilson"
         coverUrl = ""
         pages = 1000
         year = 2016
-        publisher = Publisher(UUID.randomUUID().toString(), "Test")
+        publisher = PublisherData(UUID.randomUUID().toString(), "Test")
         available = false
-        mediaType = MediaType.PAPER
+        mediaType = MediaTypeData.PAPER
         rating = 2.5f
     }
 }

--- a/data_room/src/main/java/dominando/android/data_room/BookConverter.kt
+++ b/data_room/src/main/java/dominando/android/data_room/BookConverter.kt
@@ -4,7 +4,8 @@ import dominando.android.data.model.BookData
 import dominando.android.data_room.entity.Book as BookEntity
 import java.util.UUID
 
-object BookConverter {
+internal object BookConverter {
+
     fun fromData(binding: BookData) = BookEntity(
             if (binding.id.isBlank()) UUID.randomUUID().toString() else binding.id,
             binding.title,

--- a/data_room/src/main/java/dominando/android/data_room/BookConverter.kt
+++ b/data_room/src/main/java/dominando/android/data_room/BookConverter.kt
@@ -1,11 +1,11 @@
 package dominando.android.data_room
 
-import dominando.android.data.model.Book
+import dominando.android.data.model.BookData
 import dominando.android.data_room.entity.Book as BookEntity
 import java.util.UUID
 
 object BookConverter {
-    fun fromData(binding: Book) = BookEntity(
+    fun fromData(binding: BookData) = BookEntity(
             if (binding.id.isBlank()) UUID.randomUUID().toString() else binding.id,
             binding.title,
             binding.author,
@@ -18,16 +18,16 @@ object BookConverter {
             binding.rating
     )
 
-    fun toData(entity: BookEntity) = Book().apply {
+    fun toData(entity: BookEntity) = BookData().apply {
         id = entity.id
         title = entity.title
         author = entity.author
         coverUrl = entity.coverUrl
         pages = entity.pages
         year = entity.year
-        publisher = entity.publisher
+        publisher = entity.publisherData
         available = entity.available
-        mediaType = entity.mediaType
+        mediaType = entity.mediaTypeData
         rating = entity.rating
     }
 }

--- a/data_room/src/main/java/dominando/android/data_room/RoomLocalDataImpl.kt
+++ b/data_room/src/main/java/dominando/android/data_room/RoomLocalDataImpl.kt
@@ -1,22 +1,22 @@
 package dominando.android.data_room
 
-import dominando.android.data.BooksRepository
-import dominando.android.data.model.Book
-import dominando.android.data.util.FileHelper
+import dominando.android.data.model.BookData
+import dominando.android.data.source.RoomLocalData
+import dominando.android.data_room.filehelper.FileHelper
 import dominando.android.data_room.database.AppDatabase
 import java.lang.RuntimeException
 import java.util.UUID
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 
-class RoomRepository(
+class RoomLocalDataImpl(
     db: AppDatabase,
     private val fileHelper: FileHelper
-) : BooksRepository {
+) : RoomLocalData {
 
     private val bookDao = db.bookDao()
 
-    override suspend fun saveBook(book: Book) {
+    override suspend fun saveBook(book: BookData) {
         if (book.id.isBlank()) {
             book.id = UUID.randomUUID().toString()
         }
@@ -27,7 +27,7 @@ class RoomRepository(
         }
     }
 
-    override fun loadBooks(): Flow<List<Book>> {
+    override fun loadBooks(): Flow<List<BookData>> {
         return bookDao.bookByTitle()
                 .map { books ->
                     books.map { book ->
@@ -36,12 +36,12 @@ class RoomRepository(
                 }
     }
 
-    override fun loadBook(bookId: String): Flow<Book?> {
+    override fun loadBook(bookId: String): Flow<BookData?> {
         return bookDao.bookById(bookId)
                 .map { book -> BookConverter.toData(book) }
     }
 
-    override suspend fun remove(book: Book) {
+    override suspend fun remove(book: BookData) {
         bookDao.delete(BookConverter.fromData(book))
         fileHelper.deleteExistingCover(book)
     }

--- a/data_room/src/main/java/dominando/android/data_room/RoomLocalDataImpl.kt
+++ b/data_room/src/main/java/dominando/android/data_room/RoomLocalDataImpl.kt
@@ -9,7 +9,7 @@ import java.util.UUID
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 
-class RoomLocalDataImpl(
+internal class RoomLocalDataImpl(
     db: AppDatabase,
     private val fileHelper: FileHelper
 ) : RoomLocalData {

--- a/data_room/src/main/java/dominando/android/data_room/converters/MediaTypeConverter.kt
+++ b/data_room/src/main/java/dominando/android/data_room/converters/MediaTypeConverter.kt
@@ -3,7 +3,7 @@ package dominando.android.data_room.converters
 import androidx.room.TypeConverter
 import dominando.android.data.model.MediaTypeData
 
-class MediaTypeConverter {
+internal class MediaTypeConverter {
     @TypeConverter
     fun fromMediaType(value: MediaTypeData): Int {
         return value.let { value.ordinal }

--- a/data_room/src/main/java/dominando/android/data_room/converters/MediaTypeConverter.kt
+++ b/data_room/src/main/java/dominando/android/data_room/converters/MediaTypeConverter.kt
@@ -1,16 +1,16 @@
 package dominando.android.data_room.converters
 
 import androidx.room.TypeConverter
-import dominando.android.data.model.MediaType
+import dominando.android.data.model.MediaTypeData
 
 class MediaTypeConverter {
     @TypeConverter
-    fun fromMediaType(value: MediaType): Int {
+    fun fromMediaType(value: MediaTypeData): Int {
         return value.let { value.ordinal }
     }
 
     @TypeConverter
-    fun toMediaType(value: Int): MediaType {
-        return MediaType.values()[value]
+    fun toMediaType(value: Int): MediaTypeData {
+        return MediaTypeData.values()[value]
     }
 }

--- a/data_room/src/main/java/dominando/android/data_room/dao/BookDao.kt
+++ b/data_room/src/main/java/dominando/android/data_room/dao/BookDao.kt
@@ -9,7 +9,7 @@ import dominando.android.data_room.entity.Book
 import kotlinx.coroutines.flow.Flow
 
 @Dao
-interface BookDao {
+internal interface BookDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun save(book: Book)
 

--- a/data_room/src/main/java/dominando/android/data_room/database/AppDatabase.kt
+++ b/data_room/src/main/java/dominando/android/data_room/database/AppDatabase.kt
@@ -8,7 +8,8 @@ import dominando.android.data_room.dao.BookDao
 import dominando.android.data_room.entity.Book
 
 @Database(entities = [Book::class], version = 1, exportSchema = false)
-abstract class AppDatabase : RoomDatabase() {
+internal abstract class AppDatabase : RoomDatabase() {
+
     abstract fun bookDao(): BookDao
 
     companion object {

--- a/data_room/src/main/java/dominando/android/data_room/di/DataRoomModules.kt
+++ b/data_room/src/main/java/dominando/android/data_room/di/DataRoomModules.kt
@@ -1,0 +1,20 @@
+package dominando.android.data_room.di
+
+import dominando.android.data.source.RoomLocalData
+import dominando.android.data_room.RoomLocalDataImpl
+import dominando.android.data_room.database.AppDatabase
+import dominando.android.data_room.filehelper.LocalFileHelper
+import org.koin.core.context.loadKoinModules
+import org.koin.dsl.module
+
+object DataRoomModules {
+
+    fun load() {
+        loadKoinModules(module {
+            single<RoomLocalData> {
+                RoomLocalDataImpl(AppDatabase.getDatabase(context = get()), LocalFileHelper())
+                // FbRepository() as BooksRepository
+            }
+        })
+    }
+}

--- a/data_room/src/main/java/dominando/android/data_room/di/DataRoomModules.kt
+++ b/data_room/src/main/java/dominando/android/data_room/di/DataRoomModules.kt
@@ -13,7 +13,6 @@ object DataRoomModules {
         loadKoinModules(module {
             single<RoomLocalData> {
                 RoomLocalDataImpl(AppDatabase.getDatabase(context = get()), LocalFileHelper())
-                // FbRepository() as BooksRepository
             }
         })
     }

--- a/data_room/src/main/java/dominando/android/data_room/entity/Book.kt
+++ b/data_room/src/main/java/dominando/android/data_room/entity/Book.kt
@@ -4,23 +4,23 @@ import androidx.room.Embedded
 import androidx.room.Entity
 import androidx.room.PrimaryKey
 import androidx.room.TypeConverters
-import dominando.android.data.model.MediaType
-import dominando.android.data.model.Publisher
+import dominando.android.data.model.MediaTypeData
+import dominando.android.data.model.PublisherData
 import dominando.android.data_room.converters.MediaTypeConverter
 
 @Entity
 @TypeConverters(MediaTypeConverter::class)
 data class Book(
-    @PrimaryKey
+        @PrimaryKey
     var id: String,
-    var title: String = "",
-    var author: String = "",
-    var coverUrl: String = "",
-    var pages: Int = 0,
-    var year: Int = 0,
-    @Embedded(prefix = "publisher_")
-    var publisher: Publisher,
-    var available: Boolean = false,
-    var mediaType: MediaType = MediaType.PAPER,
-    var rating: Float = 0f
+        var title: String = "",
+        var author: String = "",
+        var coverUrl: String = "",
+        var pages: Int = 0,
+        var year: Int = 0,
+        @Embedded(prefix = "publisher_")
+    var publisherData: PublisherData,
+        var available: Boolean = false,
+        var mediaTypeData: MediaTypeData = MediaTypeData.PAPER,
+        var rating: Float = 0f
 )

--- a/data_room/src/main/java/dominando/android/data_room/entity/Book.kt
+++ b/data_room/src/main/java/dominando/android/data_room/entity/Book.kt
@@ -10,7 +10,7 @@ import dominando.android.data_room.converters.MediaTypeConverter
 
 @Entity
 @TypeConverters(MediaTypeConverter::class)
-data class Book(
+internal data class Book(
         @PrimaryKey
     var id: String,
         var title: String = "",

--- a/data_room/src/main/java/dominando/android/data_room/filehelper/FileHelper.kt
+++ b/data_room/src/main/java/dominando/android/data_room/filehelper/FileHelper.kt
@@ -1,0 +1,8 @@
+package dominando.android.data_room.filehelper
+
+import dominando.android.data.model.BookData
+
+interface FileHelper {
+    fun saveCover(book: BookData): Boolean
+    fun deleteExistingCover(book: BookData): Boolean
+}

--- a/data_room/src/main/java/dominando/android/data_room/filehelper/FileHelper.kt
+++ b/data_room/src/main/java/dominando/android/data_room/filehelper/FileHelper.kt
@@ -2,7 +2,7 @@ package dominando.android.data_room.filehelper
 
 import dominando.android.data.model.BookData
 
-interface FileHelper {
+internal interface FileHelper {
     fun saveCover(book: BookData): Boolean
     fun deleteExistingCover(book: BookData): Boolean
 }

--- a/data_room/src/main/java/dominando/android/data_room/filehelper/LocalFileHelper.kt
+++ b/data_room/src/main/java/dominando/android/data_room/filehelper/LocalFileHelper.kt
@@ -1,17 +1,17 @@
-package dominando.android.data_room
+package dominando.android.data_room.filehelper
 
 import android.util.Log
-import dominando.android.data.model.Book
-import dominando.android.data.util.FileHelper
+import dominando.android.data.model.BookData
 import java.io.File
 
 class LocalFileHelper : FileHelper {
-    override fun saveCover(book: Book): Boolean {
+
+    override fun saveCover(book: BookData): Boolean {
         Log.d("NGVL", "saveCover: ${book.coverUrl}")
         return true
     }
 
-    override fun deleteExistingCover(book: Book): Boolean {
+    override fun deleteExistingCover(book: BookData): Boolean {
         return if (book.coverUrl.startsWith("file:")) {
             val coverFile = File(book.coverUrl.replace("file://", ""))
             return if (coverFile.exists()) {

--- a/data_room/src/main/java/dominando/android/data_room/filehelper/LocalFileHelper.kt
+++ b/data_room/src/main/java/dominando/android/data_room/filehelper/LocalFileHelper.kt
@@ -4,7 +4,7 @@ import android.util.Log
 import dominando.android.data.model.BookData
 import java.io.File
 
-class LocalFileHelper : FileHelper {
+internal class LocalFileHelper : FileHelper {
 
     override fun saveCover(book: BookData): Boolean {
         Log.d("NGVL", "saveCover: ${book.coverUrl}")

--- a/domain/build.gradle
+++ b/domain/build.gradle
@@ -2,8 +2,6 @@ apply plugin: 'java-library'
 apply plugin: 'kotlin'
 
 dependencies {
-    implementation project(":data")
-
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutines_version"
 

--- a/domain/build.gradle
+++ b/domain/build.gradle
@@ -1,10 +1,7 @@
 apply plugin: 'java-library'
 apply plugin: 'kotlin'
+apply from: "$rootProject.projectDir/commons.gradle"
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutines_version"
-
-    testImplementation "junit:junit:$junit_version"
     testImplementation "io.mockk:mockk:$mockk_version"
 }

--- a/domain/src/main/java/dominando/android/domain/di/DomainModules.kt
+++ b/domain/src/main/java/dominando/android/domain/di/DomainModules.kt
@@ -1,0 +1,20 @@
+package dominando.android.domain.di
+
+import dominando.android.domain.interactor.ListBooksUseCase
+import dominando.android.domain.interactor.RemoveBookUseCase
+import dominando.android.domain.interactor.SaveBookUseCase
+import dominando.android.domain.interactor.ViewBookDetailsUseCase
+import org.koin.core.context.loadKoinModules
+import org.koin.dsl.module
+
+object DomainModules {
+
+    fun load() {
+        loadKoinModules(module {
+            factory { ListBooksUseCase(repository = get()) }
+            factory { RemoveBookUseCase(repository = get()) }
+            factory { ViewBookDetailsUseCase(repository = get()) }
+            factory { SaveBookUseCase(repository = get()) }
+        })
+    }
+}

--- a/domain/src/main/java/dominando/android/domain/entity/Book.kt
+++ b/domain/src/main/java/dominando/android/domain/entity/Book.kt
@@ -1,4 +1,4 @@
-package dominando.android.data.model
+package dominando.android.domain.entity
 
 data class Book(
     var id: String = "",

--- a/domain/src/main/java/dominando/android/domain/entity/MediaType.kt
+++ b/domain/src/main/java/dominando/android/domain/entity/MediaType.kt
@@ -1,0 +1,5 @@
+package dominando.android.domain.entity
+
+enum class MediaType {
+    PAPER, EBOOK
+}

--- a/domain/src/main/java/dominando/android/domain/entity/Publisher.kt
+++ b/domain/src/main/java/dominando/android/domain/entity/Publisher.kt
@@ -1,4 +1,4 @@
-package dominando.android.data.model
+package dominando.android.domain.entity
 
 data class Publisher(
     var id: String = "",

--- a/domain/src/main/java/dominando/android/domain/interactor/ListBooksUseCase.kt
+++ b/domain/src/main/java/dominando/android/domain/interactor/ListBooksUseCase.kt
@@ -1,12 +1,11 @@
 package dominando.android.domain.interactor
 
-import dominando.android.data.BooksRepository
-import dominando.android.data.model.Book
+import dominando.android.domain.entity.Book
+import dominando.android.domain.repository.BooksRepository
 import kotlinx.coroutines.flow.Flow
 
-open class ListBooksUseCase(
-    private val repository: BooksRepository
-) {
+open class ListBooksUseCase(private val repository: BooksRepository) {
+
     fun execute(): Flow<List<Book>> {
         return repository.loadBooks()
     }

--- a/domain/src/main/java/dominando/android/domain/interactor/RemoveBookUseCase.kt
+++ b/domain/src/main/java/dominando/android/domain/interactor/RemoveBookUseCase.kt
@@ -1,11 +1,10 @@
 package dominando.android.domain.interactor
 
-import dominando.android.data.BooksRepository
-import dominando.android.data.model.Book
+import dominando.android.domain.entity.Book
+import dominando.android.domain.repository.BooksRepository
 
-open class RemoveBookUseCase(
-    private val repository: BooksRepository
-) {
+open class RemoveBookUseCase(private val repository: BooksRepository) {
+
     suspend fun execute(params: Book) {
         repository.remove(params)
     }

--- a/domain/src/main/java/dominando/android/domain/interactor/SaveBookUseCase.kt
+++ b/domain/src/main/java/dominando/android/domain/interactor/SaveBookUseCase.kt
@@ -1,12 +1,11 @@
 package dominando.android.domain.interactor
 
-import dominando.android.data.BooksRepository
-import dominando.android.data.model.Book
+import dominando.android.domain.entity.Book
+import dominando.android.domain.repository.BooksRepository
 import java.util.Calendar
 
-open class SaveBookUseCase(
-    private val repository: BooksRepository
-) {
+open class SaveBookUseCase(private val repository: BooksRepository) {
+
     suspend fun execute(params: Book) {
         return if (bookIsValid(params)) {
             repository.saveBook(params)

--- a/domain/src/main/java/dominando/android/domain/interactor/ViewBookDetailsUseCase.kt
+++ b/domain/src/main/java/dominando/android/domain/interactor/ViewBookDetailsUseCase.kt
@@ -1,12 +1,11 @@
 package dominando.android.domain.interactor
 
-import dominando.android.data.BooksRepository
-import dominando.android.data.model.Book
+import dominando.android.domain.entity.Book
+import dominando.android.domain.repository.BooksRepository
 import kotlinx.coroutines.flow.Flow
 
-open class ViewBookDetailsUseCase(
-    private val repository: BooksRepository
-) {
+open class ViewBookDetailsUseCase(private val repository: BooksRepository) {
+
     fun execute(bookId: String): Flow<Book?> {
         return repository.loadBook(bookId)
     }

--- a/domain/src/main/java/dominando/android/domain/repository/BooksRepository.kt
+++ b/domain/src/main/java/dominando/android/domain/repository/BooksRepository.kt
@@ -1,6 +1,6 @@
-package dominando.android.data
+package dominando.android.domain.repository
 
-import dominando.android.data.model.Book
+import dominando.android.domain.entity.Book
 import kotlinx.coroutines.flow.Flow
 
 interface BooksRepository {

--- a/domain/src/test/java/dominando/android/domain/ListBooksUseCaseTest.kt
+++ b/domain/src/test/java/dominando/android/domain/ListBooksUseCaseTest.kt
@@ -1,8 +1,8 @@
 package dominando.android.domain
 
-import dominando.android.data.BooksRepository
 import dominando.android.domain.data.DataFactory
 import dominando.android.domain.interactor.ListBooksUseCase
+import dominando.android.domain.repository.BooksRepository
 import io.mockk.coEvery
 import io.mockk.mockk
 import kotlinx.coroutines.flow.first

--- a/domain/src/test/java/dominando/android/domain/ListBooksUseCaseTest.kt
+++ b/domain/src/test/java/dominando/android/domain/ListBooksUseCaseTest.kt
@@ -1,6 +1,6 @@
 package dominando.android.domain
 
-import dominando.android.domain.data.DataFactory
+import dominando.android.domain.data.DomainEntityFactory
 import dominando.android.domain.interactor.ListBooksUseCase
 import dominando.android.domain.repository.BooksRepository
 import io.mockk.coEvery
@@ -15,7 +15,7 @@ import org.junit.Test
 class ListBooksUseCaseTest {
     private val repository: BooksRepository = mockk()
 
-    private val dummyBooksList = DataFactory.dummyBookList()
+    private val dummyBooksList = DomainEntityFactory.dummyBookList()
 
     @Before
     fun init() {

--- a/domain/src/test/java/dominando/android/domain/RemoveBookUseCaseTest.kt
+++ b/domain/src/test/java/dominando/android/domain/RemoveBookUseCaseTest.kt
@@ -1,8 +1,8 @@
 package dominando.android.domain
 
-import dominando.android.data.BooksRepository
 import dominando.android.domain.data.DataFactory
 import dominando.android.domain.interactor.RemoveBookUseCase
+import dominando.android.domain.repository.BooksRepository
 import io.mockk.coEvery
 import io.mockk.mockk
 import kotlinx.coroutines.runBlocking

--- a/domain/src/test/java/dominando/android/domain/RemoveBookUseCaseTest.kt
+++ b/domain/src/test/java/dominando/android/domain/RemoveBookUseCaseTest.kt
@@ -1,6 +1,6 @@
 package dominando.android.domain
 
-import dominando.android.domain.data.DataFactory
+import dominando.android.domain.data.DomainEntityFactory
 import dominando.android.domain.interactor.RemoveBookUseCase
 import dominando.android.domain.repository.BooksRepository
 import io.mockk.coEvery
@@ -13,7 +13,7 @@ class RemoveBookUseCaseTest {
 
     private val repository: BooksRepository = mockk()
 
-    private val dummyBook = DataFactory.dummyBook()
+    private val dummyBook = DomainEntityFactory.dummyBook()
 
     @Before
     fun init() {

--- a/domain/src/test/java/dominando/android/domain/SaveBookUseCaseTest.kt
+++ b/domain/src/test/java/dominando/android/domain/SaveBookUseCaseTest.kt
@@ -1,8 +1,8 @@
 package dominando.android.domain
 
-import dominando.android.data.BooksRepository
 import dominando.android.domain.data.DataFactory
 import dominando.android.domain.interactor.SaveBookUseCase
+import dominando.android.domain.repository.BooksRepository
 import io.mockk.coEvery
 import io.mockk.mockk
 import kotlinx.coroutines.runBlocking

--- a/domain/src/test/java/dominando/android/domain/SaveBookUseCaseTest.kt
+++ b/domain/src/test/java/dominando/android/domain/SaveBookUseCaseTest.kt
@@ -1,6 +1,6 @@
 package dominando.android.domain
 
-import dominando.android.domain.data.DataFactory
+import dominando.android.domain.data.DomainEntityFactory
 import dominando.android.domain.interactor.SaveBookUseCase
 import dominando.android.domain.repository.BooksRepository
 import io.mockk.coEvery
@@ -13,7 +13,7 @@ class SaveBookUseCaseTest {
 
     private val repository: BooksRepository = mockk()
 
-    private val dummyBook = DataFactory.dummyBook()
+    private val dummyBook = DomainEntityFactory.dummyBook()
 
     @Before
     fun init() {

--- a/domain/src/test/java/dominando/android/domain/ViewBookDetailsUseCaseTest.kt
+++ b/domain/src/test/java/dominando/android/domain/ViewBookDetailsUseCaseTest.kt
@@ -1,6 +1,6 @@
 package dominando.android.domain
 
-import dominando.android.domain.data.DataFactory
+import dominando.android.domain.data.DomainEntityFactory
 import dominando.android.domain.interactor.ViewBookDetailsUseCase
 import dominando.android.domain.repository.BooksRepository
 import io.mockk.coEvery
@@ -16,7 +16,7 @@ class ViewBookDetailsUseCaseTest {
 
     private val repository: BooksRepository = mockk()
 
-    private val dummyBook = DataFactory.dummyBook()
+    private val dummyBook = DomainEntityFactory.dummyBook()
 
     @Before
     fun init() {

--- a/domain/src/test/java/dominando/android/domain/ViewBookDetailsUseCaseTest.kt
+++ b/domain/src/test/java/dominando/android/domain/ViewBookDetailsUseCaseTest.kt
@@ -1,8 +1,8 @@
 package dominando.android.domain
 
-import dominando.android.data.BooksRepository
 import dominando.android.domain.data.DataFactory
 import dominando.android.domain.interactor.ViewBookDetailsUseCase
+import dominando.android.domain.repository.BooksRepository
 import io.mockk.coEvery
 import io.mockk.mockk
 import kotlinx.coroutines.flow.first

--- a/domain/src/test/java/dominando/android/domain/data/DataFactory.kt
+++ b/domain/src/test/java/dominando/android/domain/data/DataFactory.kt
@@ -1,8 +1,8 @@
 package dominando.android.domain.data
 
-import dominando.android.data.model.Book
-import dominando.android.data.model.MediaType
-import dominando.android.data.model.Publisher
+import dominando.android.domain.entity.Book
+import dominando.android.domain.entity.MediaType
+import dominando.android.domain.entity.Publisher
 import java.util.UUID
 
 object DataFactory {

--- a/domain/src/test/java/dominando/android/domain/data/DomainEntityFactory.kt
+++ b/domain/src/test/java/dominando/android/domain/data/DomainEntityFactory.kt
@@ -5,7 +5,8 @@ import dominando.android.domain.entity.MediaType
 import dominando.android.domain.entity.Publisher
 import java.util.UUID
 
-object DataFactory {
+object DomainEntityFactory {
+
     fun dummyBookList() = listOf(
             Book().apply {
                 id = UUID.randomUUID().toString()

--- a/presentation/build.gradle
+++ b/presentation/build.gradle
@@ -2,6 +2,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-kapt'
 apply plugin: 'kotlin-android-extensions'
+apply from: "$rootProject.projectDir/commons.gradle"
 
 android {
     compileSdkVersion compile_sdk_version
@@ -30,16 +31,11 @@ android {
 
 dependencies {
     implementation project(":domain")
-    implementation project(":data")
-    implementation project(":data_room")
-    implementation project(":data_fb")
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation "androidx.lifecycle:lifecycle-extensions:$lifecycle_version"
     implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:$lifecycle_version"
 
-    implementation "org.koin:koin-core:$koin_version"
-    implementation "org.koin:koin-android:$koin_version"
     implementation "org.koin:koin-android-viewmodel:$koin_version"
 
     testImplementation "junit:junit:$junit_version"

--- a/presentation/src/main/java/dominando/android/presentation/binding/BookConverter.kt
+++ b/presentation/src/main/java/dominando/android/presentation/binding/BookConverter.kt
@@ -1,8 +1,8 @@
 package dominando.android.presentation.binding
 
-import dominando.android.data.model.Book
-import dominando.android.data.model.MediaType
-import dominando.android.data.model.Publisher
+import dominando.android.domain.entity.Book
+import dominando.android.domain.entity.MediaType
+import dominando.android.domain.entity.Publisher
 import dominando.android.presentation.binding.Book as BookBinding
 import dominando.android.presentation.binding.MediaType as MediaTypeBinding
 import dominando.android.presentation.binding.Publisher as PublisherBinding

--- a/presentation/src/main/java/dominando/android/presentation/di/PresentationModule.kt
+++ b/presentation/src/main/java/dominando/android/presentation/di/PresentationModule.kt
@@ -1,8 +1,8 @@
 package dominando.android.presentation.di
 
-import dominando.android.data.BooksRepository
-import dominando.android.data_room.LocalFileHelper
-import dominando.android.data_room.RoomRepository
+import dominando.android.domain.repository.BooksRepository
+import dominando.android.data_room.filehelper.LocalFileHelper
+import dominando.android.data_room.RoomLocalDataImpl
 import dominando.android.data_room.database.AppDatabase
 import dominando.android.domain.interactor.ListBooksUseCase
 import dominando.android.domain.interactor.RemoveBookUseCase
@@ -17,7 +17,7 @@ import org.koin.dsl.module
 val presentationModule = module {
 
     single {
-        RoomRepository(AppDatabase.getDatabase(context = get()), LocalFileHelper()) as BooksRepository
+        RoomLocalDataImpl(AppDatabase.getDatabase(context = get()), LocalFileHelper()) as BooksRepository
         // FbRepository() as BooksRepository
     }
 

--- a/presentation/src/main/java/dominando/android/presentation/di/PresentationModule.kt
+++ b/presentation/src/main/java/dominando/android/presentation/di/PresentationModule.kt
@@ -1,51 +1,27 @@
 package dominando.android.presentation.di
 
-import dominando.android.domain.repository.BooksRepository
-import dominando.android.data_room.filehelper.LocalFileHelper
-import dominando.android.data_room.RoomLocalDataImpl
-import dominando.android.data_room.database.AppDatabase
-import dominando.android.domain.interactor.ListBooksUseCase
-import dominando.android.domain.interactor.RemoveBookUseCase
-import dominando.android.domain.interactor.SaveBookUseCase
-import dominando.android.domain.interactor.ViewBookDetailsUseCase
 import dominando.android.presentation.BookDetailsViewModel
 import dominando.android.presentation.BookFormViewModel
 import dominando.android.presentation.BookListViewModel
 import org.koin.android.viewmodel.dsl.viewModel
+import org.koin.core.context.loadKoinModules
 import org.koin.dsl.module
 
-val presentationModule = module {
+object PresentationModule {
 
-    single {
-        RoomLocalDataImpl(AppDatabase.getDatabase(context = get()), LocalFileHelper()) as BooksRepository
-        // FbRepository() as BooksRepository
-    }
+    fun load() {
+        loadKoinModules(module {
+            viewModel {
+                BookListViewModel(removeBookUseCase = get(), loadBooksUseCase = get())
+            }
 
-    factory {
-        ListBooksUseCase(repository = get())
-    }
+            viewModel {
+                (bookId: String) -> BookDetailsViewModel(bookId, viewBookDetailsUseCase = get())
+            }
 
-    factory {
-        RemoveBookUseCase(repository = get())
-    }
-
-    factory {
-        ViewBookDetailsUseCase(repository = get())
-    }
-
-    factory {
-        SaveBookUseCase(repository = get())
-    }
-
-    viewModel {
-        BookListViewModel(removeBookUseCase = get(), loadBooksUseCase = get())
-    }
-
-    viewModel {
-        (bookId: String) -> BookDetailsViewModel(bookId, viewBookDetailsUseCase = get())
-    }
-
-    viewModel {
-        BookFormViewModel(saveBookUseCase = get())
+            viewModel {
+                BookFormViewModel(saveBookUseCase = get())
+            }
+        })
     }
 }

--- a/presentation/src/test/java/dominando/android/presentation/DetailViewModelTest.kt
+++ b/presentation/src/test/java/dominando/android/presentation/DetailViewModelTest.kt
@@ -1,7 +1,7 @@
 package dominando.android.presentation
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
-import dominando.android.data.model.Book
+import dominando.android.domain.entity.Book
 import dominando.android.domain.interactor.ViewBookDetailsUseCase
 import dominando.android.presentation.binding.BookConverter
 import dominando.android.presentation.data.DataFactory

--- a/presentation/src/test/java/dominando/android/presentation/ListBooksViewModelTest.kt
+++ b/presentation/src/test/java/dominando/android/presentation/ListBooksViewModelTest.kt
@@ -1,7 +1,7 @@
 package dominando.android.presentation
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
-import dominando.android.data.model.Book
+import dominando.android.domain.entity.Book
 import dominando.android.domain.interactor.ListBooksUseCase
 import dominando.android.domain.interactor.RemoveBookUseCase
 import dominando.android.presentation.binding.BookConverter

--- a/presentation/src/test/java/dominando/android/presentation/data/DataFactory.kt
+++ b/presentation/src/test/java/dominando/android/presentation/data/DataFactory.kt
@@ -1,8 +1,8 @@
 package dominando.android.presentation.data
 
 import dominando.android.data.model.Book
-import dominando.android.data.model.MediaType
-import dominando.android.data.model.Publisher
+import dominando.android.data.model.MediaTypeData
+import dominando.android.data.model.PublisherData
 import java.util.UUID
 
 object DataFactory {
@@ -14,9 +14,9 @@ object DataFactory {
                 available = true
                 coverUrl = ""
                 pages = 954
-                publisher = Publisher(UUID.randomUUID().toString(), "Novatec")
+                publisher = PublisherData(UUID.randomUUID().toString(), "Novatec")
                 year = 2018
-                mediaType = MediaType.PAPER
+                mediaType = MediaTypeData.PAPER
                 rating = 5f
             },
             Book().apply {
@@ -26,9 +26,9 @@ object DataFactory {
                 available = true
                 coverUrl = ""
                 pages = 465
-                publisher = Publisher(UUID.randomUUID().toString(), "Outro")
+                publisher = PublisherData(UUID.randomUUID().toString(), "Outro")
                 year = 2009
-                mediaType = MediaType.EBOOK
+                mediaType = MediaTypeData.EBOOK
                 rating = 5f
             }
     )
@@ -40,9 +40,9 @@ object DataFactory {
         available = true
         coverUrl = ""
         pages = 954
-        publisher = Publisher(UUID.randomUUID().toString(), "Novatec")
+        publisher = PublisherData(UUID.randomUUID().toString(), "Novatec")
         year = 2018
-        mediaType = MediaType.EBOOK
+        mediaType = MediaTypeData.EBOOK
         rating = 5f
     }
 }

--- a/presentation/src/test/java/dominando/android/presentation/data/DataFactory.kt
+++ b/presentation/src/test/java/dominando/android/presentation/data/DataFactory.kt
@@ -1,8 +1,8 @@
 package dominando.android.presentation.data
 
-import dominando.android.data.model.Book
-import dominando.android.data.model.MediaTypeData
-import dominando.android.data.model.PublisherData
+import dominando.android.domain.entity.Book
+import dominando.android.domain.entity.MediaType
+import dominando.android.domain.entity.Publisher
 import java.util.UUID
 
 object DataFactory {
@@ -14,9 +14,9 @@ object DataFactory {
                 available = true
                 coverUrl = ""
                 pages = 954
-                publisher = PublisherData(UUID.randomUUID().toString(), "Novatec")
+                publisher = Publisher(UUID.randomUUID().toString(), "Novatec")
                 year = 2018
-                mediaType = MediaTypeData.PAPER
+                mediaType = MediaType.PAPER
                 rating = 5f
             },
             Book().apply {
@@ -26,9 +26,9 @@ object DataFactory {
                 available = true
                 coverUrl = ""
                 pages = 465
-                publisher = PublisherData(UUID.randomUUID().toString(), "Outro")
+                publisher = Publisher(UUID.randomUUID().toString(), "Outro")
                 year = 2009
-                mediaType = MediaTypeData.EBOOK
+                mediaType = MediaType.EBOOK
                 rating = 5f
             }
     )
@@ -40,9 +40,9 @@ object DataFactory {
         available = true
         coverUrl = ""
         pages = 954
-        publisher = PublisherData(UUID.randomUUID().toString(), "Novatec")
+        publisher = Publisher(UUID.randomUUID().toString(), "Novatec")
         year = 2018
-        mediaType = MediaTypeData.EBOOK
+        mediaType = MediaType.EBOOK
         rating = 5f
     }
 }


### PR DESCRIPTION
Hi, Glauber. I'm Gabriel and I would like to contribute with your repository. I know you from some talks and I'm a big fã of your book. 😆.

Enjoying the hacktober, I see a good improvement. When we're using clean arch we need make the domain agnostic by all layers of project, following the idea of ports and adapters (Implemented by hexagonal) I created the abstractions of data making the domain not know anything about that layer. 😃 

With this update I include the ISP (Interface Segregation Principle) to data layer, to improve and make more simple if some person would like use two or more data sources. Koin works better with this logic because register the key in graph with the reified type declared in generic. 

To we can isolate implementations with internal modifier I create an individual archive by layer to load koin modules.

I update the by inject<T> of koin to viewModel<T> in fragments to we can have this instance in Fragment lifecycle.

I included the tests and run the others to grant the quality. 🚀 